### PR TITLE
fix: :bug: prevent race condition in MQTT queue cleanup on satellite reconnect

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -152,6 +152,11 @@ async def lifespan(app: FastAPI):  # noqa: ARG001
                     except Exception as close_error:
                         logger.warning("Error closing WebSocket: %s", close_error)
 
+                # Clear stale queue mappings since all WebSocket connections are being closed.
+                # The WebSocket finally blocks will also attempt cleanup, but clearing here
+                # ensures no stale entries persist across MQTT reconnections.
+                sup_util.mqtt_subscription_to_queue.clear()
+
                 await asyncio.sleep(reconnect_delay)
                 # Exponential backoff with maximum limit
                 reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay)
@@ -275,8 +280,6 @@ async def setup_satellite_connection(websocket: WebSocket):
     # Subscribe to client-specific topic (MQTT is guaranteed to be connected)
     await sup_util.mqtt_client.subscribe(output_topic, qos=1)
 
-    sup_util.mqtt_subscription_to_queue[sup_util.config_obj.broadcast_topic] = output_queue
-
     # AIDEV-NOTE: New ground station protocol - handle satellite communication
     audio_processor = processing_sound.SatelliteAudioProcessor(
         websocket=websocket, config_obj=sup_util.config_obj, client_conf=client_conf, logger=logger, sup_util=sup_util
@@ -350,6 +353,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
     sup_util.active_connections[connection_id] = websocket
     output_topic = None
+    output_queue = None
     client_room = None
 
     try:
@@ -376,8 +380,15 @@ async def websocket_endpoint(websocket: WebSocket):
             del sup_util.active_connections[connection_id]
             logger.debug("Removed connection %s from active connections", connection_id)
 
-        # Cleanup MQTT subscription queue mapping for satellite-specific topic
-        if output_topic and output_topic in sup_util.mqtt_subscription_to_queue:
+        # Cleanup MQTT subscription queue mapping for satellite-specific topic.
+        # Only delete if the mapping still points to THIS connection's queue (identity check).
+        # This prevents a reconnecting satellite's new queue from being deleted by the
+        # old connection's cleanup.
+        if (
+            output_topic
+            and output_queue is not None
+            and sup_util.mqtt_subscription_to_queue.get(output_topic) is output_queue
+        ):
             del sup_util.mqtt_subscription_to_queue[output_topic]
             logger.debug("Removed MQTT queue mapping for topic: %s", output_topic)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -407,6 +407,9 @@ class TestWebSocketHandling:
         # Verify MQTT subscription
         mock_sup_util.mqtt_client.subscribe.assert_called_once_with("assistant/test_room/output", qos=1)
 
+        # Verify broadcast topic is NOT added to queue dict (it's handled separately in listen())
+        assert "test/broadcast" not in mock_sup_util.mqtt_subscription_to_queue
+
     async def test_setup_satellite_connection_invalid_config(self, mock_websocket):
         """Test satellite connection setup with invalid config."""
         # Setup invalid config data
@@ -499,6 +502,69 @@ class TestWebSocketEndpoint:
         # so we can't easily verify the exact call, but we can verify
         # the connection is cleaned up
         assert len(mock_sup_util.active_connections) == 0
+
+    @patch("app.main.setup_satellite_connection")
+    @patch("app.main.handle_satellite_messages")
+    @patch("app.main.sup_util")
+    async def test_websocket_cleanup_does_not_delete_new_queue(
+        self, mock_sup_util, mock_handle_messages, mock_setup, mock_websocket
+    ):
+        """Test that cleanup of old connection does not delete a newer connection's queue."""
+        old_queue = asyncio.Queue()
+        new_queue = asyncio.Queue()
+        topic = "assistant/bedroom/output"
+
+        real_queue_dict = {topic: old_queue}
+        mock_sup_util.mqtt_subscription_to_queue = real_queue_dict
+        mock_sup_util.active_connections = {}
+        mock_sup_util.mqtt_connected = True
+
+        mock_client_conf = MagicMock()
+        mock_client_conf.output_topic = topic
+        mock_client_conf.room = "bedroom"
+        mock_audio_processor = MagicMock()
+
+        mock_setup.return_value = (mock_client_conf, old_queue, mock_audio_processor)
+
+        async def simulate_reconnect(*_args, **_kwargs):
+            # While the old connection is "handling messages", a new connection overwrites the queue
+            real_queue_dict[topic] = new_queue
+
+        mock_handle_messages.side_effect = simulate_reconnect
+
+        await websocket_endpoint(mock_websocket)
+
+        # The new_queue should still be in the dict -- old cleanup must NOT have deleted it
+        assert topic in real_queue_dict
+        assert real_queue_dict[topic] is new_queue
+
+    @patch("app.main.setup_satellite_connection")
+    @patch("app.main.handle_satellite_messages")
+    @patch("app.main.sup_util")
+    async def test_websocket_cleanup_deletes_own_queue(
+        self, mock_sup_util, mock_handle_messages, mock_setup, mock_websocket
+    ):
+        """Test that cleanup deletes the queue when it still belongs to this connection."""
+        own_queue = asyncio.Queue()
+        topic = "assistant/living_room/output"
+
+        real_queue_dict = {topic: own_queue}
+        mock_sup_util.mqtt_subscription_to_queue = real_queue_dict
+        mock_sup_util.active_connections = {}
+        mock_sup_util.mqtt_connected = True
+
+        mock_client_conf = MagicMock()
+        mock_client_conf.output_topic = topic
+        mock_client_conf.room = "living_room"
+        mock_audio_processor = MagicMock()
+
+        mock_setup.return_value = (mock_client_conf, own_queue, mock_audio_processor)
+        mock_handle_messages.return_value = None
+
+        await websocket_endpoint(mock_websocket)
+
+        # Queue should be removed since no other connection overwrote it
+        assert topic not in real_queue_dict
 
 
 class TestMessageDecoding:


### PR DESCRIPTION
When a satellite reconnects before the old connection's finally block completes, the old cleanup was unconditionally deleting the queue entry by topic key, destroying the new connection's queue. This caused "seems to have no queue. Discarding message" warnings.

Fix uses object identity check (is) so cleanup only removes a queue mapping if it still belongs to this connection. Also removes unused broadcast topic mapping from setup and clears stale queue entries on MQTT disconnect.